### PR TITLE
Renamed admin.$userId route to fix the routing issue

### DIFF
--- a/app/routes/admin_.$userId.jsx
+++ b/app/routes/admin_.$userId.jsx
@@ -22,6 +22,7 @@ export async function loader({ params }) {
       content: noteObject.noteContent,
     };
   });
+  // console.log('checkpoint')
   return { entries: notesFormatted, userId };
 };
 
@@ -50,7 +51,9 @@ export const action = async ({ request }) => {
   }
 };
 
-export default function Notes() {
+export default function NotesAdmin() {
+  // console.log('component level')
+
   const data = useActionData();
   const { entries: notes, userId } = useLoaderData();
 


### PR DESCRIPTION
Without the "admin_" REMIX assumes the layout of admin route. By escaping it with "_" at the end we can ask Remix to use the default root layout. 